### PR TITLE
Updates PHPUnit to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,22 +198,6 @@ $client = new Snorlax\RestClient([
 ]);
 ```
 
-# API Authorization
-
-`Snorlax` supports two types of Authorization for now: `Bearer` and `Basic`. They're pretty easy to use.
-
-```php
-<?php
-
-$client = new Snorlax\RestClient([
-    // ...
-]);
-// Basic authorization
-$client->setAuthMethod(new Snorlax\Auth\BasicAuth('user', 'password'));
-// Bearer authorization
-$client->setAuthMethod(new Snorlax\Auth\BearerAuth('your token'));
-```
-
 # Using a custom client
 
 If you don't want to use `Guzzle`'s default client (or want to mock one), `Snorlax` accepts any class that implements `GuzzleHttp\ClientInterface`, so just pass your custom client in the constructor. Can be an instance or a callable.

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
         "kevinrob/guzzle-cache-middleware": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
-        "mockery/mockery": "0.9.*"
+        "phpunit/phpunit": "~5.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/RestClient.php
+++ b/src/RestClient.php
@@ -151,17 +151,6 @@ class RestClient
     }
 
     /**
-     * Changes the authentication method on all the requests made by this client
-     * @param \Snorlax\Auth\Authorization $auth The authorizaztion method
-     */
-    public function setAuthMethod(Authorization $auth)
-    {
-        $this->client->setDefaultOption('headers', [
-            'Authorization' => sprintf('%s %s', $auth->getAuthType(), $auth->getCredentials())
-        ]);
-    }
-
-    /**
      * Returns the internal client
      * @return \GuzzleHttp\ClientInterface
      */

--- a/tests/unit/ResourceTest.php
+++ b/tests/unit/ResourceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Mockery as m;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Response;
 
 /**
@@ -16,15 +16,12 @@ class ResourceTest extends TestCase
         ]);
         $mock = new Response(200, [], $json);
 
-        $guzzle = m::mock('GuzzleHttp\ClientInterface');
-        $guzzle
-            ->shouldReceive('request')
-            ->with('GET', 'pokemons/', [])
-            ->once()
-            ->andReturn($mock);
+        $guzzle = $this->prophesize(ClientInterface::class);
+        $guzzle->request('GET', 'pokemons/', [])
+            ->willReturn($mock);
 
         $client = $this->getRestClient([
-            'custom' => $guzzle
+            'custom' => $guzzle->reveal()
         ]);
 
         $response = $client->pokemons->all();
@@ -43,15 +40,12 @@ class ResourceTest extends TestCase
         ]);
         $mock = new Response(200, [], $json);
 
-        $guzzle = m::mock('GuzzleHttp\ClientInterface');
-        $guzzle
-            ->shouldReceive('request')
-            ->with('GET', 'pokemons/143', [])
-            ->once()
-            ->andReturn($mock);
+        $guzzle = $this->prophesize(ClientInterface::class);
+        $guzzle->request('GET', 'pokemons/143', [])
+            ->willReturn($mock);
 
         $client = $this->getRestClient([
-            'custom' => $guzzle
+            'custom' => $guzzle->reveal()
         ]);
 
         $response = $client->pokemons->get(143);
@@ -67,15 +61,12 @@ class ResourceTest extends TestCase
     {
         $mock = new Response(201);
 
-        $guzzle = m::mock('GuzzleHttp\ClientInterface');
-        $guzzle
-            ->shouldReceive('request')
-            ->with('POST', 'pokemons/', ['body' => ['pokemon_id' => 143]])
-            ->once()
-            ->andReturn($mock);
+        $guzzle = $this->prophesize(ClientInterface::class);
+        $guzzle->request('POST', 'pokemons/', ['body' => ['pokemon_id' => 143]])
+            ->willReturn($mock);
 
         $client = $this->getRestClient([
-            'custom' => $guzzle
+            'custom' => $guzzle->reveal()
         ]);
 
         $response = $client->pokemons->capture([
@@ -89,15 +80,12 @@ class ResourceTest extends TestCase
     {
         $mock = new Response(204);
 
-        $guzzle = m::mock('GuzzleHttp\ClientInterface');
-        $guzzle
-            ->shouldReceive('request')
-            ->with('PATCH', 'pokemons/143/144/rest', [])
-            ->once()
-            ->andReturn($mock);
+        $guzzle = $this->prophesize(ClientInterface::class);
+        $guzzle->request('PATCH', 'pokemons/143/144/rest', [])
+            ->willReturn($mock);
 
         $client = $this->getRestClient([
-            'custom' => $guzzle
+            'custom' => $guzzle->reveal()
         ]);
 
         $response = $client->pokemons->attack(143, 144, 'rest');

--- a/tests/unit/RestClientTest.php
+++ b/tests/unit/RestClientTest.php
@@ -1,6 +1,8 @@
 <?php
 
-use Mockery as m;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Client;
+
 use Snorlax\Auth\BearerAuth;
 
 /**
@@ -8,10 +10,6 @@ use Snorlax\Auth\BearerAuth;
  */
 class RestClientTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-    }
 
     /**
      * Verifies that the constructor correctly sets the resources
@@ -38,14 +36,14 @@ class RestClientTest extends TestCase
      */
     public function testCustomClientWithInstance()
     {
-        $custom_client = m::mock('GuzzleHttp\ClientInterface');
+        $custom_client = $this->prophesize(ClientInterface::class);
 
         $client = $this->getRestClient([
-            'custom' => $custom_client,
+            'custom' => $custom_client->reveal(),
             'params' => []
         ]);
 
-        $this->assertSame($custom_client, $client->getOriginalClient());
+        $this->assertSame($custom_client->reveal(), $client->getOriginalClient());
     }
 
     /**
@@ -53,15 +51,15 @@ class RestClientTest extends TestCase
      */
     public function testCustomClientWithClosure()
     {
-        $custom_client = m::mock('GuzzleHttp\ClientInterface');
+        $custom_client = $this->prophesize(ClientInterface::class);
         $client = $this->getRestClient([
             'custom' => function (array $params) use ($custom_client) {
-                return $custom_client;
+                return $custom_client->reveal();
             },
             'params' => []
         ]);
 
-        $this->assertSame($custom_client, $client->getOriginalClient());
+        $this->assertSame($custom_client->reveal(), $client->getOriginalClient());
     }
 
     /**
@@ -69,17 +67,17 @@ class RestClientTest extends TestCase
      */
     public function testClientWithCacheAndDebug()
     {
-        $custom_client = m::mock('GuzzleHttp\ClientInterface');
+        $custom_client = $this->prophesize(ClientInterface::class);
 
         $client = $this->getRestClient([
-            'custom' => $custom_client,
+            'custom' => $custom_client->reveal(),
             'params' => [
                 'defaults' => ['debug' => true],
                 'cache' => true
             ]
         ]);
 
-        $this->assertSame($custom_client, $client->getOriginalClient());
+        $this->assertSame($custom_client->reveal(), $client->getOriginalClient());
     }
 
     /**
@@ -87,15 +85,6 @@ class RestClientTest extends TestCase
      */
     public function testSetAuthMethod()
     {
-        $custom_client = m::mock('GuzzleHttp\ClientInterface');
-        $custom_client
-            ->shouldReceive('setDefaultOption')
-            ->once()
-            ->with('headers', ['Authorization' => 'Bearer token']);
-
-        $client = $this->getRestClient([
-            'custom' => $custom_client
-        ]);
-        $client->setAuthMethod(new BearerAuth('token'));
+        $this->markTestSkipped('The GuzzleHttp 6 don\'t has the setDefaultOption method.');
     }
 }


### PR DESCRIPTION
Closes #40 

## Before
- [ ] Run `composer update`

## Test
- [ ] Run `phpunit`

## Note
I need to remove `setAuthMethod` method because this use a method of Guzzle 5 and we use the sixth version. The `GuzzleHttp\ClientInterface` don't has the `setDefaultOption` method