### PR TITLE
Auth method

### DIFF
--- a/src/Auth/Authorization.php
+++ b/src/Auth/Authorization.php
@@ -9,7 +9,7 @@ namespace Snorlax\Auth;
 interface Authorization
 {
     /**
-     * Returns the credentials/token for the Authoritzation header
+     * Returns the credentials/token for the Authorization header
      * @return string
      */
     public function getCredentials();

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -2,8 +2,6 @@
 
 namespace Snorlax;
 
-use GuzzleHttp\ClientInterface;
-
 /**
  * The mother class of all resources. Contains methods to make dynamic requests
  * defined by the Resource::getActions() method
@@ -11,7 +9,7 @@ use GuzzleHttp\ClientInterface;
 abstract class Resource
 {
     /**
-     * @var GuzzleHttp\ClientInterface
+     * @var RestClient
      */
     protected $client;
 
@@ -22,9 +20,9 @@ abstract class Resource
 
     /**
      * Initializes the client
-     * @param GuzzleHttp\ClientInterface
+     * @param RestClient
      */
-    public function __construct(ClientInterface $client)
+    public function __construct(RestClient $client)
     {
         $this->client = $client;
     }

--- a/src/RestClient.php
+++ b/src/RestClient.php
@@ -7,6 +7,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\HandlerStack;
 use Illuminate\Support\Collection;
 use Kevinrob\GuzzleCache\CacheMiddleware;
+use Psr\Http\Message\ResponseInterface;
 use Snorlax\Auth\Authorization;
 use Snorlax\Exception\ResourceNotImplemented;
 
@@ -17,17 +18,17 @@ use Snorlax\Exception\ResourceNotImplemented;
 class RestClient
 {
     /**
-     * @var GuzzleHttp\ClientInterface
+     * @var \GuzzleHttp\ClientInterface
      */
     private $client = null;
 
     /**
-     * @var Illuminate\Support\Collection
+     * @var \Illuminate\Support\Collection
      */
     private $resources = null;
 
     /**
-     * @var Illuminate\Support\Collection
+     * @var \Illuminate\Support\Collection
      */
     private $cache;
 
@@ -35,6 +36,9 @@ class RestClient
      * @var array
      */
     private $config = [];
+
+    /** @var Authorization */
+    private $authorization;
 
     /**
      * Initializes configuration parameters and resources
@@ -144,10 +148,19 @@ class RestClient
         if (is_null($instance)) {
             $class = $params['class'];
 
-            $instance = new $class($this->client);
+            $instance = new $class($this);
         }
 
         return $this->cache[$resource] = $instance;
+    }
+
+    /**
+     * Changes the authentication method on all the requests made by this client
+     * @param \Snorlax\Auth\Authorization $auth The authorizaztion method
+     */
+    public function setAuthorization(Authorization $auth)
+    {
+        $this->authorization = $auth;
     }
 
     /**
@@ -157,5 +170,24 @@ class RestClient
     public function getOriginalClient()
     {
         return $this->client;
+    }
+
+    /**
+     * @param string $method HTTP method.
+     * @param string|\Psr\Http\Message\UriInterface $uri URI object or string.
+     * @param array $options Request options to apply.
+     *
+     * @return ResponseInterface
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function request($method, $uri, $options = [])
+    {
+        if ($this->authorization !== null) {
+            $authHeader = sprintf('%s %s', $this->authorization->getAuthType(), $this->authorization->getCredentials());
+            $headers = isset($options['headers']) ? $options['headers'] : [];
+            $headers[] = ['Authorization' => $authHeader];
+            $options['headers'] = $headers;
+        }
+        return $this->client->request($method, $uri, $options);
     }
 }

--- a/src/RestClient.php
+++ b/src/RestClient.php
@@ -185,7 +185,7 @@ class RestClient
         if ($this->authorization !== null) {
             $authHeader = sprintf('%s %s', $this->authorization->getAuthType(), $this->authorization->getCredentials());
             $headers = isset($options['headers']) ? $options['headers'] : [];
-            $headers[] = ['Authorization' => $authHeader];
+            $headers['Authorization'] = $authHeader;
             $options['headers'] = $headers;
         }
         return $this->client->request($method, $uri, $options);

--- a/tests/unit/ResourceTest.php
+++ b/tests/unit/ResourceTest.php
@@ -50,7 +50,7 @@ class ResourceTest extends TestCase
 
         $response = $client->pokemons->get(143);
 
-        $this->assertEquals((object) [
+        $this->assertEquals((object)[
             'id' => 143,
             'name' => 'Snorlax'
         ], $response->pokemon);

--- a/tests/unit/RestClientTest.php
+++ b/tests/unit/RestClientTest.php
@@ -118,6 +118,6 @@ class RestClientTest extends TestCase
             }
         }
         //Middleware does not exist on the stack
-        $this->assertTrue(false, 'No CacheMiddleware named snorlax-cache was found');
+        $this->fail('No CacheMiddleware named snorlax-cache was found');
     }
 }

--- a/tests/unit/RestClientTest.php
+++ b/tests/unit/RestClientTest.php
@@ -131,12 +131,10 @@ class RestClientTest extends TestCase
         $expectedOptions = $options;
         $expectedOptions['headers']['Authorization'] = $auth->getAuthType() . ' ' . $auth->getCredentials();
 
-        $customClient = $this->createMock('GuzzleHttp\ClientInterface');
-        $customClient->expects($this->once())
-            ->method('request')
-            ->with($method, $uri, $expectedOptions);
+        $customClient = $this->prophesize('GuzzleHttp\ClientInterface');
+        $customClient->request($method, $uri, $expectedOptions)->shouldBeCalled();
 
-        $restClient = $this->getRestClient(['custom' => $customClient]);
+        $restClient = $this->getRestClient(['custom' => $customClient->reveal()]);
         $restClient->setAuthorization($auth);
         $restClient->request($method, $uri, $options);
     }

--- a/tests/unit/RestClientTest.php
+++ b/tests/unit/RestClientTest.php
@@ -112,7 +112,7 @@ class RestClientTest extends TestCase
         $stackProperty->setAccessible(true);
         $stack = $stackProperty->getValue($handlerStack);
         //Look for the middleware
-        foreach ($stack AS $stackItem) {
+        foreach ($stack as $stackItem) {
             if ($stackItem[1] === 'snorlax-cache' && $stackItem[0] instanceof CacheMiddleware) {
                 return true;
             }

--- a/tests/unit/RestClientTest.php
+++ b/tests/unit/RestClientTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Snorlax\Auth\BearerAuth;
+use Kevinrob\GuzzleCache\CacheMiddleware;
 
 /**
  * Tests for the Snorlax\RestClient class
@@ -97,5 +98,26 @@ class RestClientTest extends TestCase
             'custom' => $custom_client
         ]);
         $client->setAuthMethod(new BearerAuth('token'));
+    }
+
+    public function testClientAddsCacheMiddlewareToHandlerStackWhenNoCustomClientProvidedAndCacheEnabled()
+    {
+        $restClient = $this->getRestClient(['params' => ['cache' => true]]);
+        //Get the guzzle client to inspect it.
+        $originalClient = $restClient->getOriginalClient();
+        $handlerStack = $originalClient->getConfig('handler');
+        //The property we need to check is not accesible, make it so.
+        $reflection = new ReflectionObject($handlerStack);
+        $stackProperty = $reflection->getProperty('stack');
+        $stackProperty->setAccessible(true);
+        $stack = $stackProperty->getValue($handlerStack);
+        //Look for the middware
+        foreach ($stack AS $stackItem) {
+            if ($stackItem[1] === 'snorlax-cache' && $stackItem[0] instanceof CacheMiddleware) {
+                return true;
+            }
+        }
+        //Middleware does not exist on the stack
+        $this->assertTrue(false, 'No CacheMiddleware named snorlax-cache was found');
     }
 }

--- a/tests/unit/RestClientTest.php
+++ b/tests/unit/RestClientTest.php
@@ -129,7 +129,7 @@ class RestClientTest extends TestCase
         $auth = new \Snorlax\Auth\BasicAuth('user', 'password');
 
         $expectedOptions = $options;
-        $expectedOptions['headers'][] = ['Authorization' => $auth->getAuthType() . ' ' . $auth->getCredentials()];
+        $expectedOptions['headers']['Authorization'] = $auth->getAuthType() . ' ' . $auth->getCredentials();
 
         $customClient = $this->createMock('GuzzleHttp\ClientInterface');
         $customClient->expects($this->once())

--- a/tests/unit/RestClientTest.php
+++ b/tests/unit/RestClientTest.php
@@ -111,7 +111,7 @@ class RestClientTest extends TestCase
         $stackProperty = $reflection->getProperty('stack');
         $stackProperty->setAccessible(true);
         $stack = $stackProperty->getValue($handlerStack);
-        //Look for the middware
+        //Look for the middleware
         foreach ($stack AS $stackItem) {
             if ($stackItem[1] === 'snorlax-cache' && $stackItem[0] instanceof CacheMiddleware) {
                 return true;

--- a/tests/unit/RestClientTest.php
+++ b/tests/unit/RestClientTest.php
@@ -106,7 +106,7 @@ class RestClientTest extends TestCase
         //Get the guzzle client to inspect it.
         $originalClient = $restClient->getOriginalClient();
         $handlerStack = $originalClient->getConfig('handler');
-        //The property we need to check is not accesible, make it so.
+        //The property we need to check is not accessible, make it so.
         $reflection = new ReflectionObject($handlerStack);
         $stackProperty = $reflection->getProperty('stack');
         $stackProperty->setAccessible(true);


### PR DESCRIPTION
- Changed Resource to require RestCient instead of ClientInterface
- Changed RestClient to pass self to Resource instead of child
  ClientInterface
- Added request method in RestClient to enable other client
  implementations
- Added authorization headers in request method in RestClient.
- Updated all tests

Ref #43 